### PR TITLE
Fix Twitter placeholder & improve resume link.

### DIFF
--- a/education.html
+++ b/education.html
@@ -74,11 +74,11 @@
         <p><strong>Phone:</strong> +91 70417 99000</p>
         <p><strong>Email:</strong> yogi2724@umd.edu</p>
         <p><strong>Location:</strong> Surat, Gujarat - 394130</p>
-        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing">View Resume</a></p>
+        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing" target="_blank" rel="noopener noreferrer">View Resume</a></p>
         <div class="social-links">
             <a href="https://www.instagram.com/yogi.n.patel/" class="social-icon"><i class="fab fa-instagram"></i></a>
             <a href="https://www.linkedin.com/in/yogipatel2814" class="social-icon"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/YOUR_TWITTER" class="social-icon"><i class="fab fa-twitter"></i></a>
+            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
             <a href="https://github.com/yogi272403" class="social-icon"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/experience.html
+++ b/experience.html
@@ -105,11 +105,11 @@
         <p><strong>Phone:</strong> +91 70417 99000</p>
         <p><strong>Email:</strong> yogi2724@umd.edu</p>
         <p><strong>Location:</strong> Surat, Gujarat - 394130</p>
-        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing">View Resume</a></p>
+        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing" target="_blank" rel="noopener noreferrer">View Resume</a></p>
         <div class="social-links">
             <a href="https://www.instagram.com/yogi.n.patel/" class="social-icon"><i class="fab fa-instagram"></i></a>
             <a href="https://www.linkedin.com/in/yogipatel2814" class="social-icon"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/YOUR_TWITTER" class="social-icon"><i class="fab fa-twitter"></i></a>
+            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
             <a href="https://github.com/yogi272403" class="social-icon"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
         <p><strong>Phone:</strong> +91 70417 99000</p>
         <p><strong>Email:</strong> yogi2724@umd.edu</p>
         <p><strong>Location:</strong> Surat, Gujarat - 394130</p>
-        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing">View Resume</a></p>
+        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing" target="_blank" rel="noopener noreferrer">View Resume</a></p>
         <div class="social-links">
             <a href="https://www.instagram.com/yogi.n.patel/" class="social-icon"><i class="fab fa-instagram"></i></a>
             <a href="https://www.linkedin.com/in/yogipatel2814" class="social-icon"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/YOUR_TWITTER" class="social-icon"><i class="fab fa-twitter"></i></a>
+            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
             <a href="https://github.com/yogi272403" class="social-icon"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/publications.html
+++ b/publications.html
@@ -132,11 +132,11 @@
         <p><strong>Phone:</strong> +91 70417 99000</p>
         <p><strong>Email:</strong> yogi2724@umd.edu</p>
         <p><strong>Location:</strong> Surat, Gujarat - 394130</p>
-        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing">View Resume</a></p>
+        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing" target="_blank" rel="noopener noreferrer">View Resume</a></p>
         <div class="social-links">
             <a href="https://www.instagram.com/yogi.n.patel/" class="social-icon"><i class="fab fa-instagram"></i></a>
             <a href="https://www.linkedin.com/in/yogipatel2814" class="social-icon"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/YOUR_TWITTER" class="social-icon"><i class="fab fa-twitter"></i></a>
+            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
             <a href="https://github.com/yogi272403" class="social-icon"><i class="fab fa-github"></i></a>
         </div>
     </footer>

--- a/skills.html
+++ b/skills.html
@@ -86,11 +86,11 @@
         <p><strong>Phone:</strong> +91 70417 99000</p>
         <p><strong>Email:</strong> yogi2724@umd.edu</p>
         <p><strong>Location:</strong> Surat, Gujarat - 394130</p>
-        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing">View Resume</a></p>
+        <p><strong>Resume:</strong> <a href="https://drive.google.com/file/d/1DsYdwaOSGtzq70chW_o9Z3E6xxYfp9nd/view?usp=sharing" target="_blank" rel="noopener noreferrer">View Resume</a></p>
         <div class="social-links">
             <a href="https://www.instagram.com/yogi.n.patel/" class="social-icon"><i class="fab fa-instagram"></i></a>
             <a href="https://www.linkedin.com/in/yogipatel2814" class="social-icon"><i class="fab fa-linkedin"></i></a>
-            <a href="https://twitter.com/YOUR_TWITTER" class="social-icon"><i class="fab fa-twitter"></i></a>
+            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
             <a href="https://github.com/yogi272403" class="social-icon"><i class="fab fa-github"></i></a>
         </div>
     </footer>


### PR DESCRIPTION
## Fix Twitter & Resume Link Issues

- The Twitter link contained a placeholder (`YOUR_TWITTER`), so I updated it to a placeholder link (`#`) instead.
- The resume link now opens in a new tab (target="_blank") with (rel="noopener noreferrer") to improve user experience and security.

